### PR TITLE
Check block height to determine whether DAA is enabled

### DIFF
--- a/core/src/main/java/org/bitcoinj/params/MainNetParams.java
+++ b/core/src/main/java/org/bitcoinj/params/MainNetParams.java
@@ -17,12 +17,10 @@
 
 package org.bitcoinj.params;
 
-import org.bitcoinj.core.*;
-import org.bitcoinj.net.discovery.*;
+import org.bitcoinj.core.Sha256Hash;
+import org.bitcoinj.core.Utils;
 
-import java.net.*;
-
-import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Parameters for the main production network on which people trade goods and services.
@@ -132,6 +130,8 @@ public class MainNetParams extends AbstractBitcoinNetParams {
 
         // Aug, 1 hard fork
         uahfHeight = 478559;
+        // Nov, 13 hard fork
+        daaHeight = 504031;
         /** Activation time at which the cash HF kicks in. */
         cashHardForkActivationTime = 1510600000;
     }

--- a/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
+++ b/core/src/main/java/org/bitcoinj/params/TestNet3Params.java
@@ -17,17 +17,12 @@
 
 package org.bitcoinj.params;
 
-import java.math.BigInteger;
-import java.util.Date;
-
-import org.bitcoinj.core.AbstractBlockChain;
-import org.bitcoinj.core.Block;
-import org.bitcoinj.core.NetworkParameters;
-import org.bitcoinj.core.StoredBlock;
-import org.bitcoinj.core.Utils;
-import org.bitcoinj.core.VerificationException;
+import org.bitcoinj.core.*;
 import org.bitcoinj.store.BlockStore;
 import org.bitcoinj.store.BlockStoreException;
+
+import java.math.BigInteger;
+import java.util.Date;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -76,6 +71,8 @@ public class TestNet3Params extends AbstractBitcoinNetParams {
 
         // Aug, 1 hard fork
         uahfHeight = 1155876;
+        // Nov, 13 hard fork
+        daaHeight = 1188697;
 
         /** Activation time at which the cash HF kicks in. */
         cashHardForkActivationTime = 1510600000;


### PR DESCRIPTION
Making the testnet working as before Nov, 13 hard fork.
I've get some inspiration from the Bitcoin ABC repo. If I'm not wrong, the point here is just check the next cash work required if DAA is enabled (the current block comes after the hard fork block).

https://github.com/Bitcoin-ABC/bitcoin-abc/blob/18d936f7416d878b5ca1ce359902f099839488ac/src/pow.cpp#L109
https://github.com/Bitcoin-ABC/bitcoin-abc/blob/6c9c42ccb093820d5dd6f32f02c657c25ce5f823/src/validation.cpp#L622

Regards,