### PR TITLE
make JDK 7 the minimum version supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Release notes are [here](docs/Releases.md).
 
 ### Technologies
 
-* Java 6 for the core modules, Java 8 for everything else
+* Java 7 for the core modules, Java 8 for everything else
 * [Maven 3+](http://maven.apache.org) - for building the project
 * [Orchid](https://github.com/subgraph/Orchid) - for secure communications over [TOR](https://www.torproject.org)
 * [Google Protocol Buffers](https://github.com/google/protobuf) - for use with serialization and hardware communications

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -112,12 +112,12 @@
 
     <build>
         <plugins>
-            <!-- Ensure compilation is done under Java 6 for backwards compatibility -->
+            <!-- Ensure compilation is done under Java 7 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
We should move away from supporting JDK 6.