### PR TITLE
Add POW rules for Regtest

### DIFF
--- a/core/src/main/java/org/bitcoinj/pow/rule/RegTestRuleChecker.java
+++ b/core/src/main/java/org/bitcoinj/pow/rule/RegTestRuleChecker.java
@@ -1,0 +1,17 @@
+package org.bitcoinj.pow.rule;
+
+import org.bitcoinj.core.*;
+import org.bitcoinj.pow.AbstractPowRulesChecker;
+import org.bitcoinj.store.BlockStore;
+import org.bitcoinj.store.BlockStoreException;
+
+public class RegTestRuleChecker extends AbstractPowRulesChecker {
+    public RegTestRuleChecker(NetworkParameters networkParameters) {
+        super(networkParameters);
+    }
+
+    public void checkRules(StoredBlock storedPrev, Block nextBlock, BlockStore blockStore,
+                                    AbstractBlockChain blockChain) throws VerificationException, BlockStoreException {
+        // always pass
+    }
+}

--- a/core/src/test/java/org/bitcoinj/pow/POWRulesTest.java
+++ b/core/src/test/java/org/bitcoinj/pow/POWRulesTest.java
@@ -1,0 +1,16 @@
+package org.bitcoinj.pow;
+
+import org.bitcoinj.core.NetworkParameters;
+import org.bitcoinj.pow.factory.RuleCheckerFactory;
+import org.junit.Test;
+
+public class POWRulesTest {
+    private final NetworkParameters regTestParams = NetworkParameters.fromID(NetworkParameters.ID_REGTEST);
+
+    // regtest network does not have pow rule
+    @Test public void testRegtestPOW() throws Exception {
+        AbstractRuleCheckerFactory ruleCheckerFactory = RuleCheckerFactory.create(regTestParams);
+        AbstractPowRulesChecker rulesChecker = ruleCheckerFactory.getRuleChecker(null, null);
+        rulesChecker.checkRules(null, null, null, null);
+    }
+}


### PR DESCRIPTION
regtest got left out of the recent structural update of the code that handles POW verification. This adds rules for regtest which are basically no rules, POW is always enough.