### PR TITLE
Prevent hasTransactions returning null

### DIFF
--- a/core/src/main/java/org/bitcoinj/core/Block.java
+++ b/core/src/main/java/org/bitcoinj/core/Block.java
@@ -1004,7 +1004,8 @@ public class Block extends Message {
      * purely a header).
      */
     public boolean hasTransactions() {
-        return !this.transactions.isEmpty();
+        // Avoid returning null.
+        return (this.transactions != null && !this.transactions.isEmpty());
     }
 
     /**


### PR DESCRIPTION
non-critical but avoids an extra unnecessary null check/exception which annoyed me at one point.